### PR TITLE
Added getters for passwords when a server is created

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -28,6 +28,10 @@ $papertrailStatus = $server->papertrailStatus();
 $isRevoked = $server->isRevoked();
 $isReady = $server->isReady();
 $connectedServerIds = $server->network();
+
+// The following getters are available on new server instances only.
+$sudoPassword = $server->sudoPassword();
+$databasePassword = $server->databasePassword();
 ```
 
 ## Update server data

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -135,8 +135,8 @@ class Forge implements ArrayAccess, Iterator, ResourceContract
     /**
      * Returns single server.
      *
-     * @param int     $serverId
-     * @param bool    $reload   (optional) indicates whether the server should be reloaded
+     * @param int  $serverId
+     * @param bool $reload   (optional) indicates whether the server should be reloaded
      *
      * @return \Laravel\Forge\Server
      */

--- a/src/Server.php
+++ b/src/Server.php
@@ -233,8 +233,7 @@ class Server extends ApiResource
 
         if (empty($json['server'])) {
             static::throwNotFoundException();
-        }
-        else {
+        } else {
             $result = $json['server'];
         }
 
@@ -248,5 +247,4 @@ class Server extends ApiResource
 
         return new static($api, $result, $owner);
     }
-
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,8 @@ namespace Laravel\Forge;
 
 use Laravel\Forge\Exceptions\Servers\PublicKeyWasNotFound;
 use Laravel\Forge\Exceptions\Servers\ServerWasNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Laravel\Forge\Contracts\ResourceContract;
 
 class Server extends ApiResource
 {
@@ -93,6 +95,22 @@ class Server extends ApiResource
     public function privateIp()
     {
         return $this->getData('private_ip_address');
+    }
+
+    /**
+     * Server sudo password - only set on server save.
+     */
+    public function sudoPassword()
+    {
+        return $this->getData('sudo_password');
+    }
+
+    /**
+     * Server sudo password - only set on server save.
+     */
+    public function databasePassword()
+    {
+        return $this->getData('database_password');
     }
 
     /**
@@ -201,4 +219,34 @@ class Server extends ApiResource
 
         return true;
     }
+
+    /**
+     * Create new Resource instance from HTTP response.
+     *
+     * @param \Psr\Http\Message\ResponseInterface       $response
+     * @param \Laravel\Forge\ApiProvider                $api
+     * @param \Laravel\Forge\Contracts\ResourceContract $owner    = null
+     */
+    public static function createFromResponse(ResponseInterface $response, ApiProvider $api, ResourceContract $owner = null)
+    {
+        $json = json_decode((string) $response->getBody(), true);
+
+        if (empty($json['server'])) {
+            static::throwNotFoundException();
+        }
+        else {
+            $result = $json['server'];
+        }
+
+        if (!empty($json['sudo_password'])) {
+            $result['sudo_password'] = $json['sudo_password'];
+        }
+
+        if (!empty($json['database_password'])) {
+            $result['database_password'] = $json['database_password'];
+        }
+
+        return new static($api, $result, $owner);
+    }
+
 }

--- a/tests/CreateServerTest.php
+++ b/tests/CreateServerTest.php
@@ -54,6 +54,8 @@ class CreateServerTest extends TestCase
         $this->assertSame($payload['name'], $server->name());
         $this->assertSame($payload['size'], $server->size());
         $this->assertSame($payload['php_version'], $server->phpVersion());
+        $this->assertSame('secret', $server->databasePassword());
+        $this->assertSame('secret', $server->sudoPassword());
         $this->assertFalse($server->isReady());
     }
 

--- a/tests/ServersTest.php
+++ b/tests/ServersTest.php
@@ -77,6 +77,8 @@ class ServersTests extends TestCase
 
         $this->assertInstanceOf(Server::class, $server);
         $this->assertSame($data['name'], $server->name());
+        $this->assertNull($server->databasePassword());
+        $this->assertNull($server->sudoPassword());
     }
 
     /**


### PR DESCRIPTION
A functional, if slightly inelegant solution to accessing sudo and database passwords when a new server is created