### PR TITLE
guzzle client post/put type changed to `json` from `form_params`

### DIFF
--- a/src/ApiResource.php
+++ b/src/ApiResource.php
@@ -214,7 +214,7 @@ abstract class ApiResource implements ArrayAccess, ResourceContract
 
         try {
             $response = $this->getHttpClient()->request('PUT', $this->apiUrl(), [
-                'form_params' => $payload,
+                'json' => $payload,
             ]);
         } catch (RequestException $e) {
             $this->throwResourceException($e->getResponse(), 'update', UpdateResourceException::class);

--- a/src/Certificates/Certificate.php
+++ b/src/Certificates/Certificate.php
@@ -119,7 +119,7 @@ class Certificate extends ApiResource
     public function install(string $content, bool $addIntermediates = false): bool
     {
         $this->getHttpClient()->request('POST', $this->apiUrl('/install'), [
-            'form_params' => [
+            'json' => [
                 'certificate' => $content,
                 'add_intermediates' => $addIntermediates,
             ],

--- a/src/Commands/ApiCommand.php
+++ b/src/Commands/ApiCommand.php
@@ -71,7 +71,7 @@ abstract class ApiCommand
     public function requestOptions()
     {
         return [
-            'form_params' => $this->payload,
+            'json' => $this->payload,
         ];
     }
 

--- a/src/Recipes/Recipe.php
+++ b/src/Recipes/Recipe.php
@@ -55,7 +55,7 @@ class Recipe extends ApiResource
      */
     public function run(array $serverIds)
     {
-        $formParams = ['form_params' => ['servers' => $serverIds]];
+        $formParams = ['json' => ['servers' => $serverIds]];
         $this->getHttpClient()->request('POST', 'recipes/'.$this->id().'/run', $formParams);
 
         return true;

--- a/src/Servers/Factory.php
+++ b/src/Servers/Factory.php
@@ -131,7 +131,7 @@ class Factory
         ksort($payload);
 
         $response = $this->api->getClient()->request('POST', 'servers', [
-            'form_params' => $payload,
+            'json' => $payload,
         ]);
 
         return Server::createFromResponse($response, $this->api);

--- a/src/Servers/Providers/Provider.php
+++ b/src/Servers/Providers/Provider.php
@@ -323,7 +323,7 @@ abstract class Provider
         }
 
         $response = $this->api->getClient()->request('POST', 'servers', [
-            'form_params' => $this->sortPayload(),
+            'json' => $this->sortPayload(),
         ]);
 
         return Server::createFromResponse($response, $this->api);

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -57,7 +57,7 @@ class Site extends ApiResource
     public function install(ApplicationContract $application)
     {
         $this->getHttpClient()->request('POST', $this->apiUrl($application->type()), [
-            'form_params' => $application->payload(),
+            'json' => $application->payload(),
         ]);
 
         return true;

--- a/tests/CertificatesTest.php
+++ b/tests/CertificatesTest.php
@@ -186,7 +186,7 @@ class CertificatesTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/certificates', ['form_params' => $this->createPayload()])
+                        ->with('POST', 'servers/1/sites/1/certificates', ['json' => $this->createPayload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['certificate' => $this->response()])->toResponse()
                         );
@@ -215,7 +215,7 @@ class CertificatesTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/certificates', ['form_params' => $this->installPayload()])
+                        ->with('POST', 'servers/1/sites/1/certificates', ['json' => $this->installPayload()])
                         ->andReturn(
                             FakeResponse::fake()
                             ->withJson([
@@ -244,7 +244,7 @@ class CertificatesTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/certificates', ['form_params' => $this->clonePayload()])
+                        ->with('POST', 'servers/1/sites/1/certificates', ['json' => $this->clonePayload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['certificate' => $this->response()])->toResponse()
                         );
@@ -261,7 +261,7 @@ class CertificatesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/letsencrypt', [
-                            'form_params' => [
+                            'json' => [
                                 'domains' => ['example.org', 'www.example.org', 'api.example.org'],
                             ],
                         ])
@@ -289,7 +289,7 @@ class CertificatesTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/certificates', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/certificates', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -314,7 +314,7 @@ class CertificatesTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/certificates/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/certificates/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['certificate' => $this->response()])->toResponse()
                         );
@@ -354,7 +354,7 @@ class CertificatesTest extends TestCase
                 'certificate' => $this->fakeCertificate(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/certificates/1/install', [
-                            'form_params' => [
+                            'json' => [
                                 'certificate' => 'certificate',
                                 'add_intermediates' => false,
                             ]

--- a/tests/ConfigsTest.php
+++ b/tests/ConfigsTest.php
@@ -87,7 +87,7 @@ class ConfigurationsTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/nginx', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/nginx', ['json' => []])
                         ->andReturn(FakeResponse::fake()->withBody($this->nginx())->toResponse());
                 }),
                 'expectedResult' => $this->nginx(),
@@ -102,7 +102,7 @@ class ConfigurationsTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('PUT', 'servers/1/sites/1/nginx', [
-                            'form_params' => ['content' => $this->nginx()],
+                            'json' => ['content' => $this->nginx()],
                         ])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
@@ -118,7 +118,7 @@ class ConfigurationsTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/env', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/env', ['json' => []])
                         ->andReturn(FakeResponse::fake()->withBody($this->env())->toResponse());
                 }),
                 'expectedResult' => $this->env(),
@@ -133,7 +133,7 @@ class ConfigurationsTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('PUT', 'servers/1/sites/1/env', [
-                            'form_params' => ['content' => $this->env()],
+                            'json' => ['content' => $this->env()],
                         ])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),

--- a/tests/CreateServerTest.php
+++ b/tests/CreateServerTest.php
@@ -35,7 +35,7 @@ class CreateServerTest extends TestCase
 
         $api = Api::fake(function ($http) use ($payload, $response) {
             $http->shouldReceive('request')
-                ->with('POST', 'servers', ['form_params' => $payload])
+                ->with('POST', 'servers', ['json' => $payload])
                 ->andReturn(
                     FakeResponse::fake()
                         ->withJson([
@@ -64,7 +64,7 @@ class CreateServerTest extends TestCase
     {
         $api = Api::fake(function ($http) use ($payload, $response) {
             $http->shouldReceive('request')
-                ->with('POST', 'servers', ['form_params' => $payload])
+                ->with('POST', 'servers', ['json' => $payload])
                 ->andReturn(
                     FakeResponse::fake()
                         ->withJson([

--- a/tests/DaemonsTest.php
+++ b/tests/DaemonsTest.php
@@ -105,7 +105,7 @@ class DaemonsTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/daemons', [
-                            'form_params' => [
+                            'json' => [
                                 'command' => $this->command,
                                 'user' => 'forge',
                             ]
@@ -132,7 +132,7 @@ class DaemonsTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/daemons', ['form_params' => []])
+                        ->with('GET', 'servers/1/daemons', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -164,7 +164,7 @@ class DaemonsTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/daemons/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/daemons/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['daemon' => $this->response()])->toResponse()
                         );

--- a/tests/DeploymentTest.php
+++ b/tests/DeploymentTest.php
@@ -102,7 +102,7 @@ class DeploymentTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/deployment', ['form_params' => []])
+                        ->with('POST', 'servers/1/sites/1/deployment', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->toResponse()
                         );
@@ -120,7 +120,7 @@ class DeploymentTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('DELETE', 'servers/1/sites/1/deployment', ['form_params' => []])
+                        ->with('DELETE', 'servers/1/sites/1/deployment', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->toResponse()
                         );
@@ -138,7 +138,7 @@ class DeploymentTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/deployment/script', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/deployment/script', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withBody('git pull origin master')
@@ -159,7 +159,7 @@ class DeploymentTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('PUT', 'servers/1/sites/1/deployment/script', [
-                            'form_params' => [
+                            'json' => [
                                 'content' => "cd /home/forge/default\ngit pull origin master",
                             ]
                         ])
@@ -183,7 +183,7 @@ class DeploymentTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/deployment/deploy', ['form_params' => []])
+                        ->with('POST', 'servers/1/sites/1/deployment/deploy', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->toResponse()
                         );
@@ -201,7 +201,7 @@ class DeploymentTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/deployment/reset', ['form_params' => []])
+                        ->with('POST', 'servers/1/sites/1/deployment/reset', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->toResponse()
                         );
@@ -229,7 +229,7 @@ class DeploymentTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) use ($log) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/deployment/log', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/deployment/log', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withBody($log)

--- a/tests/FirewallTest.php
+++ b/tests/FirewallTest.php
@@ -91,7 +91,7 @@ class FirewallTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/firewall-rules', [
-                            'form_params' => [
+                            'json' => [
                                 'name' => 'rule name',
                                 'port' => 88,
                             ],
@@ -119,7 +119,7 @@ class FirewallTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/firewall-rules', ['form_params' => []])
+                        ->with('GET', 'servers/1/firewall-rules', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -151,7 +151,7 @@ class FirewallTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/firewall-rules/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/firewall-rules/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['rule' => $this->response()])->toResponse()
                         );

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -83,7 +83,7 @@ class JobsTest extends TestCase
         return Api::fakeServer(function ($http) use ($payload, $response) {
             $http->shouldReceive('request')
                 ->with('POST', 'servers/1/jobs', [
-                    'form_params' => $payload,
+                    'json' => $payload,
                 ])
                 ->andReturn(
                     FakeResponse::fake()
@@ -221,7 +221,7 @@ class JobsTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/jobs', ['form_params' => []])
+                        ->with('GET', 'servers/1/jobs', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -253,7 +253,7 @@ class JobsTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/jobs/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/jobs/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['job' => $this->response()])->toResponse()
                         );

--- a/tests/MysqlDatabasesTest.php
+++ b/tests/MysqlDatabasesTest.php
@@ -83,7 +83,7 @@ class MysqlDatabasesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/mysql', [
-                            'form_params' => ['name' => 'forge'],
+                            'json' => ['name' => 'forge'],
                         ])
                         ->andReturn(
                             FakeResponse::fake()
@@ -102,7 +102,7 @@ class MysqlDatabasesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/mysql', [
-                            'form_params' => [
+                            'json' => [
                                 'name' => 'forge',
                                 'user' => 'forge',
                                 'password' => 'secret',
@@ -135,7 +135,7 @@ class MysqlDatabasesTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/mysql', ['form_params' => []])
+                        ->with('GET', 'servers/1/mysql', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -167,7 +167,7 @@ class MysqlDatabasesTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/mysql/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/mysql/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['database' => $this->response()])->toResponse()
                         );

--- a/tests/MysqlUsersTest.php
+++ b/tests/MysqlUsersTest.php
@@ -121,7 +121,7 @@ class MysqlUsersTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/mysql-users', ['form_params' => $this->payload()])
+                        ->with('POST', 'servers/1/mysql-users', ['json' => $this->payload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['user' => $this->response()])->toResponse()
                         );
@@ -137,7 +137,7 @@ class MysqlUsersTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/mysql-users', ['form_params' => []])
+                        ->with('GET', 'servers/1/mysql-users', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -171,7 +171,7 @@ class MysqlUsersTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/mysql-users/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/mysql-users/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['user' => $this->response()])->toResponse()
                         );
@@ -194,7 +194,7 @@ class MysqlUsersTest extends TestCase
                 'user' => $this->fakeUser(function ($http) {
                     $http->shouldReceive('request')
                         ->with('PUT', 'servers/1/mysql-users/1', [
-                            'form_params' => [
+                            'json' => [
                                 'databases' => [1, 2],
                             ]
                         ])

--- a/tests/RecipesTest.php
+++ b/tests/RecipesTest.php
@@ -140,7 +140,7 @@ class RecipesTest extends TestCase
             [
                 'forge' => Api::fakeForge(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'recipes', ['form_params' => $this->payload()])
+                        ->with('POST', 'recipes', ['json' => $this->payload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['recipe' => $this->response()])->toResponse()
                         );
@@ -157,7 +157,7 @@ class RecipesTest extends TestCase
             [
                 'forge' => Api::fakeForge(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'recipes', ['form_params' => []])
+                        ->with('GET', 'recipes', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -181,7 +181,7 @@ class RecipesTest extends TestCase
             [
                 'forge' => Api::fakeForge(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'recipes/1', ['form_params' => []])
+                        ->with('GET', 'recipes/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['recipe' => $this->response()])->toResponse()
                         );
@@ -204,7 +204,7 @@ class RecipesTest extends TestCase
             [
                 'recipe' => $this->fakeRecipe(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('PUT', 'recipes/1', ['form_params' => $this->payload()])
+                        ->with('PUT', 'recipes/1', ['json' => $this->payload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['recipe' => $this->response()])->toResponse()
                         );
@@ -237,7 +237,7 @@ class RecipesTest extends TestCase
             [
                 'recipe' => $this->fakeRecipe(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'recipes/1/run', ["form_params" => ["servers" => [1,2]]])
+                        ->with('POST', 'recipes/1/run', ["json" => ["servers" => [1,2]]])
                         ->andReturn(
                             FakeResponse::fake()->toResponse()
                         );

--- a/tests/ServersTest.php
+++ b/tests/ServersTest.php
@@ -163,7 +163,7 @@ class ServersTests extends TestCase
                 );
 
             $http->shouldReceive('request')
-                ->with('PUT', 'servers/'.$data['id'], ['form_params' => $payload])
+                ->with('PUT', 'servers/'.$data['id'], ['json' => $payload])
                 ->andReturn(
                     FakeResponse::fake()->withJson(['server' => $response])->toResponse()
                 );

--- a/tests/ServicesTest.php
+++ b/tests/ServicesTest.php
@@ -129,7 +129,7 @@ class ServicesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/blackfire/install', [
-                            'form_params' => [
+                            'json' => [
                                 'server_id' => 'server-id',
                                 'server_token' => 'server-token',
                             ],
@@ -144,7 +144,7 @@ class ServicesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/papertrail/install', [
-                            'form_params' => ['host' => '192.241.143.108']
+                            'json' => ['host' => '192.241.143.108']
                         ])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
@@ -181,7 +181,7 @@ class ServicesTest extends TestCase
                 'service' => new BlackfireService(),
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('DELETE', 'servers/1/blackfire/remove', ['form_params' => []])
+                        ->with('DELETE', 'servers/1/blackfire/remove', ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => true,
@@ -190,7 +190,7 @@ class ServicesTest extends TestCase
                 'service' => new PapertrailService(),
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('DELETE', 'servers/1/papertrail/remove', ['form_params' => []])
+                        ->with('DELETE', 'servers/1/papertrail/remove', ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => true,
@@ -246,7 +246,7 @@ class ServicesTest extends TestCase
                 'service' => new MysqlService(),
                 'server' => Api::fakeServer(function ($http) use ($command) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/mysql/'.$command, ['form_params' => []])
+                        ->with('POST', 'servers/1/mysql/'.$command, ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => true,
@@ -255,7 +255,7 @@ class ServicesTest extends TestCase
                 'service' => new NginxService(),
                 'server' => Api::fakeServer(function ($http) use ($command) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/nginx/'.$command, ['form_params' => []])
+                        ->with('POST', 'servers/1/nginx/'.$command, ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => true,
@@ -264,7 +264,7 @@ class ServicesTest extends TestCase
                 'service' => new PostgresService(),
                 'server' => Api::fakeServer(function ($http) use ($command) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/postgres/'.$command, ['form_params' => []])
+                        ->with('POST', 'servers/1/postgres/'.$command, ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => true,
@@ -287,7 +287,7 @@ class ServicesTest extends TestCase
                 'service' => new MysqlService(),
                 'server' => Api::multipleFakeServers(3, function ($http, $serverId) use ($command) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/'.$serverId.'/mysql/'.$command, ['form_params' => []])
+                        ->with('POST', 'servers/'.$serverId.'/mysql/'.$command, ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => [
@@ -300,7 +300,7 @@ class ServicesTest extends TestCase
                 'service' => new NginxService(),
                 'server' => Api::multipleFakeServers(3, function ($http, $serverId) use ($command) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/'.$serverId.'/nginx/'.$command, ['form_params' => []])
+                        ->with('POST', 'servers/'.$serverId.'/nginx/'.$command, ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => [
@@ -313,7 +313,7 @@ class ServicesTest extends TestCase
                 'service' => new PostgresService(),
                 'server' => Api::multipleFakeServers(3, function ($http, $serverId) use ($command) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/'.$serverId.'/postgres/'.$command, ['form_params' => []])
+                        ->with('POST', 'servers/'.$serverId.'/postgres/'.$command, ['json' => []])
                         ->andReturn(FakeResponse::fake()->toResponse());
                 }),
                 'expectedResult' => [

--- a/tests/SitesTest.php
+++ b/tests/SitesTest.php
@@ -123,7 +123,7 @@ class SitesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites', [
-                            'form_params' => $this->payload(),
+                            'json' => $this->payload(),
                         ])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['site' => Api::siteData()])->toResponse()
@@ -145,7 +145,7 @@ class SitesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites', [
-                            'form_params' => $this->payload(),
+                            'json' => $this->payload(),
                         ])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['site' => Api::siteData()])->toResponse()
@@ -167,7 +167,7 @@ class SitesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites', [
-                            'form_params' => $this->payload(['project_type' => 'html']),
+                            'json' => $this->payload(['project_type' => 'html']),
                         ])
                         ->andReturn(
                             FakeResponse::fake()->withJson([
@@ -192,7 +192,7 @@ class SitesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites', [
-                            'form_params' => $this->payload(['project_type' => 'html']),
+                            'json' => $this->payload(['project_type' => 'html']),
                         ])
                         ->andReturn(
                             FakeResponse::fake()->withJson([
@@ -217,7 +217,7 @@ class SitesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites', [
-                            'form_params' => $this->payload(['project_type' => 'symfony']),
+                            'json' => $this->payload(['project_type' => 'symfony']),
                         ])
                         ->andReturn(
                             FakeResponse::fake()->withJson([
@@ -242,7 +242,7 @@ class SitesTest extends TestCase
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites', [
-                            'form_params' => $this->payload(['project_type' => 'symfony_dev']),
+                            'json' => $this->payload(['project_type' => 'symfony_dev']),
                         ])
                         ->andReturn(
                             FakeResponse::fake()->withJson([
@@ -272,7 +272,7 @@ class SitesTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -305,7 +305,7 @@ class SitesTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['site' => Api::siteData()])->toResponse()
                         );
@@ -327,7 +327,7 @@ class SitesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('PUT', 'servers/1/sites/1', [
-                            'form_params' => ['directory' => '/some/path']
+                            'json' => ['directory' => '/some/path']
                         ])
                         ->andReturn(
                             FakeResponse::fake()
@@ -350,7 +350,7 @@ class SitesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/git', [
-                            'form_params' => [
+                            'json' => [
                                 'provider' => 'github',
                                 'repository' => 'username/repository',
                             ],
@@ -364,7 +364,7 @@ class SitesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/git', [
-                            'form_params' => [
+                            'json' => [
                                 'provider' => 'bitbucket',
                                 'repository' => 'username/repository',
                             ],
@@ -378,7 +378,7 @@ class SitesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/git', [
-                            'form_params' => [
+                            'json' => [
                                 'provider' => 'gitlab',
                                 'repository' => 'username/repository',
                             ],
@@ -392,7 +392,7 @@ class SitesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/git', [
-                            'form_params' => [
+                            'json' => [
                                 'provider' => 'custom',
                                 'repository' => 'git@example.org:username/repository.git',
                             ],
@@ -406,7 +406,7 @@ class SitesTest extends TestCase
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
                         ->with('POST', 'servers/1/sites/1/wordpress', [
-                            'form_params' => [
+                            'json' => [
                                 'database' => 'forge',
                                 'user' => 'forge',
                             ],

--- a/tests/SshKeysTest.php
+++ b/tests/SshKeysTest.php
@@ -88,7 +88,7 @@ class SshKeysTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/keys', ['form_params' => $this->payload()])
+                        ->with('POST', 'servers/1/keys', ['json' => $this->payload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['key' => $this->response()])->toResponse()
                         );
@@ -108,7 +108,7 @@ class SshKeysTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/keys', ['form_params' => []])
+                        ->with('GET', 'servers/1/keys', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()
                                 ->withJson([
@@ -140,7 +140,7 @@ class SshKeysTest extends TestCase
             [
                 'server' => Api::fakeServer(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/keys/1', ['form_params' => []])
+                        ->with('GET', 'servers/1/keys/1', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['key' => $this->response()])->toResponse()
                         );

--- a/tests/WorkersTest.php
+++ b/tests/WorkersTest.php
@@ -97,7 +97,7 @@ class WorkersTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('POST', 'servers/1/sites/1/workers', ['form_params' => $this->payload()])
+                        ->with('POST', 'servers/1/sites/1/workers', ['json' => $this->payload()])
                         ->andReturn(
                             FakeResponse::fake()->withJson(['worker' => $this->response()])->toResponse()
                         );
@@ -127,7 +127,7 @@ class WorkersTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/workers', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/workers', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson([
                                 'workers' => [
@@ -161,7 +161,7 @@ class WorkersTest extends TestCase
             [
                 'site' => Api::fakeSite(function ($http) {
                     $http->shouldReceive('request')
-                        ->with('GET', 'servers/1/sites/1/workers/2', ['form_params' => []])
+                        ->with('GET', 'servers/1/sites/1/workers/2', ['json' => []])
                         ->andReturn(
                             FakeResponse::fake()->withJson([
                                 'worker' => $this->response(['id' => 2]),


### PR DESCRIPTION
This is a rather large shift, I grant you, but I think the reasoning is sound at least.
When POSTing empty arrays using `form_params`, the request ignores the data altogether. Using `json` will send the empty array.

For example:

```php
// this gives a server access to the server with the ID 12345
$forge['example-server']->update(['network' => [12345]]);
// using form_params, this does NOT remove access to 12345
$forge['example-server']->update(['network' => []]);
```
Using `json` as the request option however, does remove network access as required

I can't think of any downsides to using this method, but there may very well be things I am not taking into account here. I will be using this in my own project for now and report back if there are any issues