### PR TITLE
load_balancer to node_balancer

### DIFF
--- a/src/Servers/Providers/Provider.php
+++ b/src/Servers/Providers/Provider.php
@@ -259,7 +259,7 @@ abstract class Provider
      */
     public function asLoadBalancer(bool $install = true)
     {
-        return $this->togglePayload('load_balancer', $install);
+        return $this->togglePayload('node_balancer', $install);
     }
 
     /**

--- a/tests/CreateServerTest.php
+++ b/tests/CreateServerTest.php
@@ -97,7 +97,7 @@ class CreateServerTest extends TestCase
         return array_merge([
             'credential_id' => 1,
             'database' => 'laravel',
-            'load_balancer' => 1,
+            'node_balancer' => 1,
             'maria' => 1,
             'name' => 'northrend',
             'network' => [1, 2, 3],


### PR DESCRIPTION
The keyword for creating a load balancer has been updated from `load_balancer` to `node_balancer`. Apparently this is Linode's term for load balancers.
I realise that this is technically a breaking change, but this has come about due to my tests on the API and the load balancer feature not working. As far as i can tell it never did work as previously documented. I can confirm that the `node_balancer` term does function as intended.