### PR TITLE
Introduces an optional request rate limiting feature

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -7,6 +7,8 @@ At the time of writing, the Laravel Forge API imposes a request rate limit of 30
 Add a rate limiting function of your choice by way of an optional closure, set on the main `$forge` instance.
 
 ```php
+<?php
+
 $forge->setRateLimiter(function() {
     rateLimitingFunction();
 });
@@ -29,6 +31,8 @@ composer require bandwidth-throttle/token-bucket
 Next, we create an in memory token bucket which will last only as long as the request/script runs. This particular package does allow for a number of storage options which are well beyond the scope of this example.
 
 ```php
+<?php
+
 use bandwidthThrottle\tokenBucket\Rate;
 use bandwidthThrottle\tokenBucket\TokenBucket;
 use bandwidthThrottle\tokenBucket\BlockingConsumer;
@@ -64,6 +68,8 @@ $forge->get(1234, true);
 Of course, the rate limiting closure could be something as simple as:
 
 ```php
+<?php 
+
 $limitingClosure = function () {
     sleep(2);
 };

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -4,7 +4,7 @@ At the time of writing, the Laravel Forge API imposes a request rate limit of 30
 
 ## Usage
 
-Add a rate limiting function of your choice by way of an optional closure, set on the main `$forge` instance.
+Add a rate limiting function of your choice by way of an optional `callable`, set on the main `$forge` instance.
 
 ```php
 <?php
@@ -14,9 +14,9 @@ $forge->setRateLimiter(function() {
 });
 ```
 
-**Please note that the `rateLimitingFunction()` is not provided, and must be provided separately.**
+**Please note that the `rateLimitingFunction()` is not provided. It is down to you to design the best fit for your needs**
 
-Now each time a request is made, the `ApiProvider` calls the rate limiting closure first. This effectively blocks the request until the closure has completed its calculation.
+Now each time a request is made, the `ApiProvider` executes the rate limiting callable first. The callable function should be designed to block the call until the program is satisfied the rate limit will not be exceeded.
 
 ## Examples
 
@@ -68,7 +68,7 @@ $forge->get(1234, true);
 Of course, the rate limiting closure could be something as simple as:
 
 ```php
-<?php 
+<?php
 
 $limitingClosure = function () {
     sleep(2);

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,74 @@
+# Overview
+
+At the time of writing, the Laravel Forge API imposes a request rate limit of 30 requests per minute. If you are only making a few, isolated requests then this won't present any issues. However, if you are running scripts to batch create servers or perhaps to grab details of all your sites at one time, you may need to limit your request rate.
+
+## Usage
+
+Add a rate limiting function of your choice by way of an optional closure, set on the main `$forge` instance.
+
+```php
+$forge->setRateLimiter(function() {
+    rateLimitingFunction();
+});
+```
+
+**Please note that the `rateLimitingFunction()` is not provided, and must be provided separately.**
+
+Now each time a request is made, the `ApiProvider` calls the rate limiting closure first. This effectively blocks the request until the closure has completed its calculation.
+
+## Examples
+
+One way of implementing rate limiting is to use a [Token Bucket Algorithm][924f3b4d].
+
+Start by including the package in your project:
+
+```bash
+composer require bandwidth-throttle/token-bucket
+```
+
+Next, we create an in memory token bucket which will last only as long as the request/script runs. This particular package does allow for a number of storage options which are well beyond the scope of this example.
+
+```php
+use bandwidthThrottle\tokenBucket\Rate;
+use bandwidthThrottle\tokenBucket\TokenBucket;
+use bandwidthThrottle\tokenBucket\BlockingConsumer;
+use bandwidthThrottle\tokenBucket\storage\SingleProcessStorage;
+
+// the Forge request rate limit
+$requestsPerMinute = 30;
+
+// create an in memory storage for the bucket
+$storage = new SingleProcessStorage();
+
+// set the request rate from above
+$rate = new Rate($requestsPerMinute, Rate::MINUTE);
+
+// create the bucket, limiting the bucket size
+$bucket = new TokenBucket(1, $rate, $storage);
+
+// set up a blocking consumer of the tokens
+$blockingConsumer = new BlockingConsumer($bucket);
+
+// create a closure which uses our new bucket
+$limitingClosure = function () use ($clockingConsumer) {
+    $blockingConsumer->consume(1);
+};
+
+// pass this closure to our $forge instance
+$forge->setRateLimiter($limitingClosure);
+
+// make automatically rate limited requests!
+$forge->get(1234, true);
+```
+
+Of course, the rate limiting closure could be something as simple as:
+
+```php
+$limitingClosure = function () {
+    sleep(2);
+};
+```
+
+Alternatively you could write your own manager. For example, the [Laravel rate limiter](https://github.com/illuminate/cache/blob/master/RateLimiter.php) (which is no doubt implemented by the Forge API) uses a [Laravel Cache instance](https://laravel.com/docs/5.4/cache).
+
+  [924f3b4d]: https://github.com/bandwidth-throttle/token-bucket "PHP Tocken Bucket implementation"

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -18,3 +18,4 @@
     + [Workers](./workers.md)
 - [Recipes](./recipes.md)
 - [SSL Certificates](./certificates.md)
+- [Rate Limiting](./rate-limiting.md)

--- a/src/ApiProvider.php
+++ b/src/ApiProvider.php
@@ -98,7 +98,7 @@ class ApiProvider
      *
      * @param \Closure
      */
-    public function setRateLimiter(Callable $rateLimiter)
+    public function setRateLimiter(callable $rateLimiter)
     {
         $this->rateLimiter = $rateLimiter;
     }

--- a/src/ApiProvider.php
+++ b/src/ApiProvider.php
@@ -54,7 +54,7 @@ class ApiProvider
     public function getClient(): ClientInterface
     {
         if (!is_null($this->rateLimiter)) {
-            ($this->rateLimiter)();
+            call_user_func($this->rateLimiter);
         }
 
         if (!is_null($this->client)) {
@@ -98,7 +98,7 @@ class ApiProvider
      *
      * @param \Closure
      */
-    public function setRateLimiter(\Closure $rateLimiter)
+    public function setRateLimiter(Callable $rateLimiter)
     {
         $this->rateLimiter = $rateLimiter;
     }

--- a/src/ApiProvider.php
+++ b/src/ApiProvider.php
@@ -28,6 +28,14 @@ class ApiProvider
      */
     protected $client;
 
+
+    /**
+     * The optional rate limiting function.
+     *
+     * @var \Closure | null
+     */
+    protected $rateLimiter = null;
+
     /**
      * Create new API provider instance.
      *
@@ -45,6 +53,10 @@ class ApiProvider
      */
     public function getClient(): ClientInterface
     {
+        if (!is_null($this->rateLimiter)) {
+            ($this->rateLimiter)();
+        }
+
         if (!is_null($this->client)) {
             return $this->client;
         }
@@ -79,5 +91,15 @@ class ApiProvider
         ]);
 
         return $client;
+    }
+
+    /**
+     * Sets an optional rate limiting function.
+     *
+     * @param \Closure
+     */
+    public function setRateLimiter(\Closure $rateLimiter)
+    {
+        $this->rateLimiter = $rateLimiter;
     }
 }

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -223,7 +223,7 @@ class Forge implements ArrayAccess, Iterator, ResourceContract
      *
      * @param \Closure
      */
-    public function setRateLimiter(Callable $rateLimiter)
+    public function setRateLimiter(callable $rateLimiter)
     {
         $this->api->setRateLimiter($rateLimiter);
     }

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -223,7 +223,7 @@ class Forge implements ArrayAccess, Iterator, ResourceContract
      *
      * @param \Closure
      */
-    public function setRateLimiter(\Closure $rateLimiter)
+    public function setRateLimiter(Callable $rateLimiter)
     {
         $this->api->setRateLimiter($rateLimiter);
     }

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -217,4 +217,14 @@ class Forge implements ArrayAccess, Iterator, ResourceContract
 
         return $this->serversCache[$serverId] = Server::createFromResponse($response, $this->api);
     }
+
+    /**
+     * Sets an optional rate limiting function on the api provider.
+     *
+     * @param \Closure
+     */
+    public function setRateLimiter(\Closure $rateLimiter)
+    {
+        $this->api->setRateLimiter($rateLimiter);
+    }
 }

--- a/tests/Helpers/Api.php
+++ b/tests/Helpers/Api.php
@@ -21,14 +21,14 @@ class Api
      */
     public static function fake(Closure $callback = null)
     {
-        $api = Mockery::mock(ApiProvider::class.'[getClient]', ['api-token']);
+        $api = Mockery::mock(ApiProvider::class.'[createClient]', ['api-token']);
         $http = Mockery::mock(Client::class);
 
         if (!is_null($callback)) {
             $callback($http);
         }
 
-        $api->shouldReceive('getClient')->andReturn($http);
+        $api->shouldReceive('createClient')->andReturn($http);
 
         return $api;
     }

--- a/tests/Helpers/FakeRateLimiter.php
+++ b/tests/Helpers/FakeRateLimiter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Tests\Forge\Helpers;
+
+class FakeRateLimiter
+{
+
+    /**
+     * The fake rate limiter count
+     *
+     * @var int
+     */
+    protected $limiterCount = 0;
+
+    /**
+     * Simulate the function call to rate limiter
+     *
+     * In the wild, this function would determine whether a delay
+     * was required; here we just increment a value to check later
+     */
+    public function limit()
+    {
+        $this->limiterCount++;
+    }
+
+    /**
+     * Returns the limiterCount
+     *
+     * @return int
+     */
+    public function getLimiterCount()
+    {
+        return $this->limiterCount;
+    }
+}

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Tests\Forge;
+
+use Laravel\Forge\Forge;
+use PHPUnit\Framework\TestCase;
+use Laravel\Tests\Forge\Helpers\Api;
+use Laravel\Tests\Forge\Helpers\FakeResponse;
+use Laravel\Tests\Forge\Helpers\FakeRateLimiter;
+
+class RateLimitTest extends TestCase
+{
+
+    /**
+     * @dataProvider rateLimitingProvider
+     */
+    public function testRateLimiting(Forge $forge, FakeRateLimiter $limiter)
+    {
+
+        // We use a fake rate limiting class method
+        // which in this case simply increments a value
+
+        // Set the function as our rate limiter
+        $forge->setRateLimiter(function () use ($limiter) {
+            $limiter->limit();
+        });
+
+        // check that no requests have been rate limited yet
+        $this->assertEquals(0, $limiter->getLimiterCount());
+
+        // make a few requests
+        $credentials = $forge->credentials();
+        $credentials = $forge->credentials();
+
+        // check that the requests have run the rate limiting closure
+        $this->assertEquals(2, $limiter->getLimiterCount());
+    }
+
+    public function rateLimitingProvider(): array
+    {
+        $api = Api::fake(function ($http) {
+            $http->shouldReceive('request')
+                ->with('GET', 'credentials')
+                ->andReturn(
+                    FakeResponse::fake()
+                        ->withJson([
+                            'credentials' => [
+                                [
+                                    'id' => 1,
+                                    'type' => 'ocean2',
+                                    'name' => 'Personal',
+                                ]
+                            ],
+                        ])
+                        ->toResponse()
+                );
+        });
+
+        return [
+            [
+                'forge' => new Forge($api),
+                'limiter' => new FakeRateLimiter(),
+            ]
+        ];
+    }
+}

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -21,9 +21,7 @@ class RateLimitTest extends TestCase
         // which in this case simply increments a value
 
         // Set the function as our rate limiter
-        $forge->setRateLimiter(function () use ($limiter) {
-            $limiter->limit();
-        });
+        $forge->setRateLimiter([$limiter, 'limit']);
 
         // check that no requests have been rate limited yet
         $this->assertEquals(0, $limiter->getLimiterCount());


### PR DESCRIPTION
So, obviously this is in a very early stage.

Essentially this allows you to register an entirely "sleep" function with the `$api` instance. Each time `getClient(` is called, if the closure has been set, it is called.

The function could be whatever you liked, from running `sleep(2)` to implementing a full [token bucket algorithm](https://github.com/bandwidth-throttle/token-bucket) for rate limiting. I have tried both, and they work well.

I will add some documentation to detail how this might be achieved in the wild. Once again, I am struggling with testing, however. Because the `getClient()` function call is mocked on the test `$api` instance, I can't find a way to ensure the closure is called.

Feedback very much appreciated.