### PR TITLE
New methods to Server Provider and Site

### DIFF
--- a/src/Servers/Providers/Provider.php
+++ b/src/Servers/Providers/Provider.php
@@ -251,6 +251,20 @@ abstract class Provider
     }
 
     /**
+     * Tells that the server should be created with recipe id to be run
+     *
+     * @param integer $recipeId
+     *
+     * @return static
+    */
+    public function runRecipe($recipeId)
+    {
+        $this->payload['recipe_id'] = $recipeId;
+
+        return $this;
+    }
+
+    /**
      * Indicates that server should be provisioned as load balancer.
      *
      * @param bool $install = true

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -215,7 +215,7 @@ class Site extends ApiResource
     public function balance(array $serverIds)
     {
         $this->getHttpClient()->request('PUT', $this->apiUrl('/balancing'), [
-            'json' => ['balancing' => $serverIds]
+            'json' => ['servers' => $serverIds]
         ]);
 
         return true;

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -215,7 +215,7 @@ class Site extends ApiResource
     public function balance(array $serverIds)
     {
         $this->getHttpClient()->request('PUT', $this->apiUrl('/balancing'), [
-            'json' => ['servers' => $serverIds]
+            'json' => ['balancing' => $serverIds]
         ]);
 
         return true;

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -158,6 +158,26 @@ class Site extends ApiResource
     }
 
     /**
+     * Site working directory.
+     *
+     * @return string | null
+     */
+    public function directory()
+    {
+        return $this->getData('directory');
+    }
+
+    /**
+     * Site creation status.
+     *
+     * @return string | null
+     */
+    public function siteStatus()
+    {
+        return $this->getData('status');
+    }
+
+    /**
      * Install new application on site.
      *
      * @param \Laravel\Forge\Contracts\ApplicationContract $application


### PR DESCRIPTION
I created a few new methods to Server Provider:
 * `Laravel\Forge\Servers\Providers\Provider::runRecipe($recipeId)` that fills the recipe_id on server payload
 * `Laravel\Forge\Sites\Site::directory()` get the directory of the site
 * `Laravel\Forge\Sites\Site::directory()` get the site status