### PR TITLE
Move from defining server size by "memory" value to defining by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $credential = $forge->credentialFor('ocean2');
 $server = $forge->create()
     ->droplet()
     ->usingCredential($credential)
-    ->withMemoryOf('1GB')
+    ->withSizeId(1)
     ->at('fra1')
     ->runningPhp('7.1')
     ->withMariaDb()

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.3",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
@@ -27,13 +27,16 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "6.3-dev"
                 }
             },
             "autoload": {
@@ -66,7 +69,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28T22:50:30+00:00"
+            "time": "2018-04-22T15:46:56+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -121,32 +124,33 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "0d6c7ca039329247e4f0f8f8f6506810e8248855"
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/0d6c7ca039329247e4f0f8f8f6506810e8248855",
-                "reference": "0d6c7ca039329247e4f0f8f8f6506810e8248855",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -176,13 +180,14 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-02-27T10:51:17+00:00"
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "psr/http-message",
@@ -233,37 +238,79 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -283,12 +330,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -337,16 +384,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.9",
+            "version": "0.9.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "be9bf28d8e57d67883cba9fcadfcff8caab667f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
-                "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/be9bf28d8e57d67883cba9fcadfcff8caab667f8",
+                "reference": "be9bf28d8e57d67883cba9fcadfcff8caab667f8",
                 "shasum": ""
             },
             "require": {
@@ -398,41 +445,47 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-02-28T12:52:32+00:00"
+            "time": "2019-02-12T16:07:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -440,20 +493,122 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -494,33 +649,39 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -539,24 +700,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -586,42 +747,42 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -649,44 +810,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.0.3",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
-                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
                 "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^2.0",
-                "sebastian/version": "^2.0"
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -701,7 +862,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -712,20 +873,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-06T14:22:16+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +920,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -853,29 +1014,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -898,20 +1059,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.0.8",
+            "version": "6.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6"
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
-                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
                 "shasum": ""
             },
             "require": {
@@ -920,22 +1081,24 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.3",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
                 "php": "^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^5.0",
-                "phpunit/php-file-iterator": "^1.4",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^4.0",
-                "sebastian/comparator": "^1.2.4 || ^2.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/environment": "^2.0",
-                "sebastian/exporter": "^2.0 || ^3.0",
-                "sebastian/global-state": "^1.1 || ^2.0",
-                "sebastian/object-enumerator": "^2.0 || ^3.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0"
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "3.0.2",
@@ -954,7 +1117,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -980,33 +1143,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-02T15:24:03+00:00"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.1",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "eabce450df194817a7d7e27e19013569a903a2bf"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/eabce450df194817a7d7e27e19013569a903a2bf",
-                "reference": "eabce450df194817a7d7e27e19013569a903a2bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
+                "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^3.0"
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1014,7 +1177,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1029,7 +1192,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1039,7 +1202,8 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-03-03T06:30:20+00:00"
+            "abandoned": true,
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1088,30 +1252,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.0",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
-                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/exporter": "^3.0"
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1142,38 +1306,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-03-03T06:26:08+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1200,32 +1364,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1250,20 +1414,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/b82d077cb3459e393abcf4867ae8f7230dcb51f6",
-                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
@@ -1277,7 +1441,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1317,27 +1481,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-03-03T06:25:06+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1345,7 +1509,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1368,25 +1532,25 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/31dd3379d16446c5d86dec32ab1ad1f378581ad8",
-                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/object-reflector": "^1.0",
+                "sebastian/object-reflector": "^1.1.1",
                 "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
@@ -1415,20 +1579,20 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-03-12T15:17:29+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "2201553542d60d25db9c5b2c54330df776648008"
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/2201553542d60d25db9c5b2c54330df776648008",
-                "reference": "2201553542d60d25db9c5b2c54330df776648008",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
@@ -1440,7 +1604,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -1460,7 +1624,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-12T15:10:22+00:00"
+            "time": "2017-03-29T09:07:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1601,21 +1765,120 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -1648,7 +1911,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/docs/create-server.md
+++ b/docs/create-server.md
@@ -18,7 +18,7 @@ $forge = new Forge($api);
 $droplet = $forge->create()
   ->droplet('my-droplet-name')
   ->usingCredential(1234)
-  ->withMemoryOf('2GB')
+  ->withSizeId(3)
   ->at('fra1')
   ->save();
 ```
@@ -37,7 +37,7 @@ $forge = new Forge($api);
 $node = $forge->create()
   ->linode('my-server-name')
   ->usingCredential(1234)
-  ->withMemoryOf('2GB')
+  ->withSizeId(3)
   ->at(1) // "1" region represents "Frankfurt"
   ->save();
 ```
@@ -56,7 +56,7 @@ $forge = new Forge($api);
 $aws = $forge->create()
   ->aws('my-server-name')
   ->usingCredential(1234)
-  ->withMemoryOf('2GB')
+  ->withSizeId(3)
   ->at('us-west-1')
   ->save();
 ```
@@ -106,7 +106,7 @@ use Laravel\Forge\Servers\Factory;
 Factory::setDefaultCredential('ocean2', 12345);
 ```
 
-After doing so you may ommit `usingCredential` method call on `DigitalOcean` provider (instance returned by `droplet` method).
+After doing so you may omit `usingCredential` method call on `DigitalOcean` provider (instance returned by `droplet` method).
 
 ```php
 <?php
@@ -117,7 +117,7 @@ $forge = new Forge($api);
 
 $droplet = $forge->create()
   ->droplet('my-droplet-name')
-  ->withMemoryOf('2GB')
+  ->withSizeId(3)
   ->at('fra1')
   ->save();
 ```
@@ -151,7 +151,7 @@ Just call `asNodeBalancer()` on methods chain to indicate that new server should
 $loadBalancer = $forge->create()
   ->droplet('balancer-01')
   ->usingCredential(1234)
-  ->withMemoryOf('512MB')
+  ->withSizeId(3)
   ->at('fra1')
   ->asNodeBalancer()
   ->save();
@@ -167,7 +167,7 @@ $loadBalancer = $forge->create()
 $droplet = $forge->create()
   ->droplet('web-01')
   ->usingCredential(1234)
-  ->withMemoryOf('512MB')
+  ->withSizeId(3)
   ->at('fra1')
   ->withMariaDb('my-database')
   ->save();
@@ -183,21 +183,21 @@ By default Forge will install MySQL server and create `forge` database. If you n
 $droplet = $forge->create()
   ->droplet('web-01')
   ->usingCredential(1234)
-  ->withMemoryOf('512MB')
+  ->withSizeId(3)
   ->at('fra1')
   ->withMysql('my-database')
   ->save();
 ```
 
 > Warning!
-> 
+>
 > Calling `withMysql` method will reset any previous `withMariaDb` calls
 > (and vice-versa). This means that if you call both methods,
 > the most latest database will be installed on new server.
 
 ## Set new server size
 
-You're required to set server size for all providers except `custom`. Use `withMemoryOf` method and pass available human readable size value for your server provider. List of possible `memory` values available [here](https://forge.laravel.com/api-documentation#server-sizes).
+You're required to set server size for all providers except `custom`. Use `withSizeId` method and pass the relevant ID for the size of server for your server provider. List of possible `ID` values available [here](./provider-sizes.md).
 
 ```php
 <?php
@@ -205,14 +205,14 @@ You're required to set server size for all providers except `custom`. Use `withM
 $heavyBackendDroplet = $forge->create()
   ->droplet('heavy-backend-01')
   ->usingCredential(1234)
-  ->withMemoryOf('32GB')
+  ->withSizeId(3)
   ->at('fra1')
   ->save();
 ```
 
 ## Set new server region
 
-With an addition to server size, you're required to provide new server region (unless you're creating Custom VPS). `at` method accepts valid region identifier for your server provider. List of possible `region` values available [here](https://forge.laravel.com/api-documentation#regions).
+With an addition to server size, you're required to provide new server region (unless you're creating Custom VPS). `at` method accepts valid region identifier for your server provider. List of possible `region` values available [here](./provider-regions.md).
 
 ```php
 <?php
@@ -220,18 +220,20 @@ With an addition to server size, you're required to provide new server region (u
 $londonDroplet = $forge->create()
   ->droplet('web-01')
   ->usingCredential(1234)
-  ->withMemoryOf('8GB')
+  ->withSizeId(3)
   ->at('lon1')
   ->save();
 ```
 
 ## Choose PHP version
 
-Forge allows to provision new servers with PHP 5.6, PHP 7.0 or PHP 7.1. You can specify PHP version by calling `runningPhp` method. Valid version arguments are:
+Forge allows to provision new servers with PHP 5.6, PHP 7.0, PHP 7.1, PHP 7.2 or PHP 7.3. You can specify PHP version by calling `runningPhp` method. Valid version arguments are:
 
 - `php56` (or `56`, or `5.6` or `php5.6`);
 - `php70` (or `70` or `7.0` or `php7.0`);
 - `php71` (or `71` or `7.1` or `php7.1`).
+- `php72` (or `72` or `7.2` or `php7.2`).
+- `php73` (or `73` or `7.3` or `php7.3`).
 
 ```php
 <?php
@@ -239,7 +241,7 @@ Forge allows to provision new servers with PHP 5.6, PHP 7.0 or PHP 7.1. You can 
 $legacyDroplet = $forge->create()
   ->droplet('web-01')
   ->usingCredential(1234)
-  ->withMemoryOf('1GB')
+  ->withSizeId(3)
   ->at('fra1')
   ->runningPhp('5.6')
   ->save();
@@ -262,7 +264,7 @@ $serverIds = [
 $web = $forge->create()
   ->droplet('web-02')
   ->usingCredential(1234)
-  ->withMemoryOf('1GB')
+  ->withSizeId(3)
   ->at('fra1')
   ->runningPhp('7.1')
   ->connectedTo($serverIds)
@@ -270,7 +272,7 @@ $web = $forge->create()
 ```
 
 > Heads Up!
-> 
+>
 > Servers can be connected to each other only if they're belongs
 > to the same server provider and the same region!
 

--- a/docs/provider-regions.md
+++ b/docs/provider-regions.md
@@ -1,0 +1,94 @@
+# Server Provider Regions
+
+This is a curated list of the regions for each of the service providers supported by Forge.
+
+### \*\*\* Please note that this is subject to change \*\*\*
+
+A complete list of provider regions and server sizes can be obtained via the Forge API, as described in the [Forge API documentation](https://forge.laravel.com/api-documentation#regions)
+
+## DigitalOcean
+
+| id   | name            |
+|------|-----------------|
+| ams2 | Amsterdam 2     |
+| ams3 | Amsterdam 3     |
+| blr1 | Bangalore       |
+| lon1 | London          |
+| fra1 | Frankfurt       |
+| nyc1 | New York 1      |
+| nyc2 | New York 2      |
+| nyc3 | New York 3      |
+| sfo1 | San Francisco 1 |
+| sfo2 | San Francisco 2 |
+| sgp1 | Singapore       |
+| tor1 | Toronto         |
+
+## Linode
+
+| id | name      |
+|----|-----------|
+| 2  | Dallas    |
+| 3  | Fremont   |
+| 4  | Atlanta   |
+| 6  | Newark    |
+| 7  | London    |
+| 9  | Singapore |
+| 10 | Frankfurt |
+| 11 | Tokyo 2   |
+
+## Linode4
+
+| id              | name      |
+|-----------------|-----------|
+| us-southeast    | Atlanta   |
+| us-central      | Dallas    |
+| eu-central      | Frankfurt |
+| us-west         | Fremont   |
+| eu-west         | London    |
+| us-east         | Newark    |
+| ap-south        | Singapore |
+| ca-central      | Toronto   |
+| ap-northeast    | Tokyo     |
+| ap-northeast-1a | Tokyo 2   |
+
+## Vultr
+
+| 7  | Amsterdam      |
+|----|----------------|
+| 1  | New Jersey     |
+| 2  | Chicago        |
+| 3  | Dallas         |
+| 4  | Seattle        |
+| 5  | Los Angeles    |
+| 6  | Atlanta        |
+| 9  | Frankfurt      |
+| 8  | London         |
+| 12 | Silicon Valley |
+| 22 | Toronto        |
+| 19 | Sydney         |
+| 24 | Paris          |
+| 25 | Tokyo          |
+| 40 | Singapore      |
+| 39 | Miami          |
+
+## AWS
+
+| id             | name           |
+|----------------|----------------|
+| ca-central-1   | Central Canada |
+| eu-west-1      | Ireland        |
+| eu-central-1   | Frankfurt      |
+| ap-east-1      | Hong Kong      |
+| eu-west-2      | London         |
+| ap-south-1     | Mumbai         |
+| us-west-1      | N. California  |
+| us-east-2      | Ohio           |
+| us-west-2      | Oregon         |
+| eu-west-3      | Paris          |
+| sa-east-1      | Sao Paulo      |
+| ap-northeast-2 | Seoul          |
+| ap-southeast-1 | Singapore      |
+| eu-north-1     | Stockholm      |
+| ap-southeast-2 | Sydney         |
+| ap-northeast-1 | Tokyo          |
+| us-east-1      | Virginia       |

--- a/docs/provider-sizes.md
+++ b/docs/provider-sizes.md
@@ -1,0 +1,125 @@
+# Server Provider Regions
+
+This is a curated list of the server sizes available at each of the service providers supported by Forge.
+
+### \*\*\* Please note that this is subject to change \*\*\*
+
+A complete list of provider regions and server sizes can be obtained via the Forge API, as described in the [Forge API documentation](https://forge.laravel.com/api-documentation#regions)
+
+## DigitalOcean
+
+| id | size           | name                                                   |
+|----|----------------|--------------------------------------------------------|
+| 1  | s-1vcpu-1gb    | 1GB RAM - 1 CPU Core - 25GB SSD                        |
+| 2  | s-3vcpu-1gb    | 1GB RAM - 3 CPU Core - 60GB SSD                        |
+| 3  | s-1vcpu-2gb    | 2GB RAM - 1 CPU Core - 50GB SSD                        |
+| 4  | s-2vcpu-2gb    | 2GB RAM - 2 CPU Core - 60GB SSD                        |
+| 5  | s-1vcpu-3gb    | 3GB RAM - 1 CPU Cores - 60GB SSD                       |
+| 6  | c-2            | 4GB RAM (High CPU) - 2 CPU Cores - 25GB SSD            |
+| 7  | s-2vcpu-4gb    | 4GB RAM - 2 CPU Cores - 80GB SSD                       |
+| 8  | s-4vcpu-8gb    | 8GB RAM - 4 CPU Cores - 160GB SSD                      |
+| 9  | c-4            | 8GB RAM (High CPU) - 4 CPU Cores - 50GB SSD            |
+| 10 | c-8            | 16GB RAM (High CPU) - 8 CPU Cores - 1000GB SSD         |
+| 11 | s-6vcpu-16gb   | 16GB RAM - 6 CPU Core - 320GB SSD                      |
+| 12 | s-8vcpu-32gb   | 32GB RAM - 8 CPU Core - 640GB SSD                      |
+| 13 | c-16           | 32GB RAM (High CPU) - 16 CPU Core - 200GB SSD          |
+| 14 | s-12vcpu-48gb  | 48GB RAM - 12 CPU Core - 960GB SSD                     |
+| 15 | s-16vcpu-64gb  | 64GB RAM - 16 CPU Core - 1280GB SSD                    |
+| 16 | c-32           | 64GB RAM (High CPU) - 32 CPU Core - 400GB SSD          |
+| 17 | s-20vcpu-96gb  | 96GB RAM - 20 CPU Core - 1920GB SSD                    |
+| 18 | s-24vcpu-128gb | 128GB RAM - 24 CPU Core - 2560GB SSD                   |
+| 19 | s-32vcpu-192gb | 192GB RAM - 32 CPU Core - 3840GB SSD                   |
+| 20 | c-1vcpu-2gb    | 2GB RAM (High CPU) - 1 CPU Cores - 25GB SSD            |
+| 21 | g-2vcpu-8gb    | 8GB RAM (General Purpose) - 2 CPU Cores - 25GB SSD     |
+| 22 | g-4vcpu-16gb   | 16GB RAM (General Purpose) - 4 CPU Cores - 50GB SSD    |
+| 23 | g-8vcpu-32gb   | 32GB RAM (General Purpose) - 8 CPU Cores - 100GB SSD   |
+| 24 | g-16vcpu-64gb  | 64GB RAM (General Purpose) - 16 CPU Cores - 200GB SSD  |
+| 25 | g-32vcpu-128gb | 128GB RAM (General Purpose) - 32 CPU Cores - 400GB SSD |
+| 26 | g-40vcpu-160gb | 160GB RAM (General Purpose) - 40 CPU Cores - 500GB SSD |
+
+
+## Linode
+
+| id | size | name                                              |
+|----|------|---------------------------------------------------|
+| 1  | 1    | 1GB RAM - 1 CPU Cores - 25GB SSD                  |
+| 2  | 2    | 2GB RAM - 1 CPU Cores - 50GB SSD                  |
+| 3  | 3    | 4GB RAM - 2 CPU Cores - 80GB SSD                  |
+| 4  | 4    | 8GB RAM - 4 CPU Cores - 160GB SSD                 |
+| 5  | 5    | 16GB RAM - 6 CPU Cores - 320GB SSD                |
+| 6  | 6    | 32GB RAM - 8 CPU Cores - 640GB SSD                |
+| 7  | 7    | 64GB RAM - 16 CPU Cores - 1280GB SSD              |
+| 8  | 8    | 96GB RAM - 20 CPU Cores - 1920GB SSD              |
+| 9  | 9    | 128GB RAM - 24 CPU Cores - 2560GB                 |
+| 11 | 11   | 24GB RAM (High Memory) - 1 CPU Core - 20GB SSD    |
+| 12 | 12   | 48GB RAM (High Memory) - 2 CPU Core - 40GB SSD    |
+| 13 | 13   | 90GB RAM (High Memory) - 4 CPU Core - 90GB SSD    |
+| 14 | 14   | 150GB RAM (High Memory) - 8 CPU Core - 200GB SSD  |
+| 15 | 15   | 300GB RAM (High Memory) - 16 CPU Core - 340GB SSD |
+
+
+## Linode4
+
+| id | size             | name                                                |
+|----|------------------|-----------------------------------------------------|
+| 1  | g6-nanode-1      | 1GB RAM - 1 CPU Cores - 25GB SSD                    |
+| 2  | g6-standard-1    | 2GB RAM - 1 CPU Cores - 50GB SSD                    |
+| 3  | g6-standard-2    | 4GB RAM - 2 CPU Cores - 80GB SSD                    |
+| 4  | g6-standard-4    | 8GB RAM - 4 CPU Cores - 160GB SSD                   |
+| 5  | g6-standard-6    | 16GB RAM - 6 CPU Cores - 320GB SSD                  |
+| 6  | g6-standard-8    | 32GB RAM - 8 CPU Cores - 640GB SSD                  |
+| 7  | g6-standard-16   | 64GB RAM - 16 CPU Cores - 1280GB SSD                |
+| 8  | g6-standard-20   | 96GB RAM - 20 CPU Cores - 1920GB SSD                |
+| 9  | g6-standard-24   | 128GB RAM - 24 CPU Cores - 2560GB SSD               |
+| 11 | g6-highmem-1     | 24GB RAM (High Memory) - 1 CPU Core - 20GB SSD      |
+| 12 | g6-highmem-2     | 48GB RAM (High Memory) - 2 CPU Cores - 40GB SSD     |
+| 13 | g6-highmem-4     | 90GB RAM (High Memory) - 4 CPU Cores - 90GB SSD     |
+| 14 | g6-highmem-8     | 150GB RAM (High Memory) - 8 CPU Cores - 200GB SSD   |
+| 15 | g6-highmem-16    | 300GB RAM (High Memory) - 16 CPU Cores - 340GB SSD  |
+| 16 | g6-dedicated-2   | 4GB RAM - 2 CPU Cores (Dedicated CPU) - 25GB SSD    |
+| 17 | g6-dedicated-4   | 8GB RAM - 4 CPU Cores (Dedicated CPU) - 50GB SSD    |
+| 18 | g6-dedicated-8   | 16GB RAM - 8 CPU Cores (Dedicated CPU) - 100GB SSD  |
+| 19 | g6-dedicated-16  | 32GB RAM - 16 CPU Cores (Dedicated CPU) - 200GB SSD |
+| 20 | g6-dedicated-32  | 64GB RAM - 32 CPU Cores (Dedicated CPU) - 400GB SSD |
+| 21 | g6-dedicated-48  | 96GB RAM - 48 CPU Cores (Dedicated CPU) - 600GB SSD |
+
+## Vultr
+
+| id | size | name                               |
+|----|------|------------------------------------|
+| 1  | 201  | 1GB RAM - 1 CPU Core - 25GB SSD    |
+| 2  | 202  | 2GB RAM - 1 CPU Core - 40GB SSD    |
+| 3  | 203  | 4GB RAM - 2 CPU Core - 60GB SSD    |
+| 4  | 204  | 8GB RAM - 4 CPU Core - 100GB SSD   |
+| 5  | 205  | 16GB RAM - 6 CPU Core - 200GB SSD  |
+| 6  | 206  | 32GB RAM - 8 CPU Core - 300GB SSD  |
+| 7  | 207  | 65GB RAM - 16 CPU Core - 400GB SSD |
+
+## AWS
+
+| id | size       | name                             |
+|----|------------|----------------------------------|
+| 1  | t2.nano    | 1 vCPUs - 0.5GB RAM (t2.nano)    |
+| 2  | t2.micro   | 1 vCPUs - 1GB RAM (t2.micro)     |
+| 3  | t2.small   | 1 vCPUs - 2GB RAM (t2.small)     |
+| 4  | t2.medium  | 2 vCPUs - 4GB RAM (t2.medium)    |
+| 5  | t2.large   | 2 vCPUs - 8GB RAM (t2.large)     |
+| 6  | t2.xlarge  | 4 vCPUs - 16GB RAM (t2.xlarge)   |
+| 7  | t2.2xlarge | 8 vCPUs - 32GB RAM (t2.2xlarge)  |
+| 8  | t3.nano    | 2 vCPUs - 0.5GB RAM (t3.nano)    |
+| 9  | t3.micro   | 2 vCPUs - 1GB RAM (t3.micro)     |
+| 10 | t3.small   | 2 vCPUs - 2GB RAM (t3.small)     |
+| 11 | t3.medium  | 2 vCPUs - 4GB RAM (t3.medium)    |
+| 12 | t3.large   | 2 vCPUs - 8GB RAM (t3.large)     |
+| 13 | t3.xlarge  | 4 vCPUs - 16GB RAM (t3.xlarge)   |
+| 14 | t3.2xlarge | 8 vCPUs - 32GB RAM (t3.2xlarge)  |
+| 19 | m5.large   | 2 vCPUs - 8GB RAM (m5.large)     |
+| 20 | m5.xlarge  | 4 vCPUs - 16GB RAM (m5.xlarge)   |
+| 15 | m5.4xlarge | 16 vCPUs - 64GB RAM (m5.4xlarge) |
+| 16 | m5.2xlarge | 8 vCPUs - 32GB RAM (m5.2xlarge)  |
+| 17 | m5d.large  | 2 vCPUs - 8GB RAM (m5d.large)    |
+| 18 | m5d.xlarge | 4 vCPUs - 16GB RAM (m5d.large)   |
+| 19 | c5.large   | 2 vCPUs - 4GB RAM (c5.large)     |
+| 20 | c5.xlarge  | 4 vCPUs - 8GB RAM (c5.xlarge)    |
+| 21 | c5.2xlarge | 8 vCPUs - 16GB RAM (c5.2xlarge)  |
+| 22 | c5.4xlarge | 16 vCPUs - 32GB RAM (c5.4xlarge) |

--- a/docs/servers.md
+++ b/docs/servers.md
@@ -75,7 +75,7 @@ $oceanCredentialId = 1234;
 $droplet = $forge->create()
     ->droplet('my-droplet-name')
     ->usingCredential($oceanCredentialId)
-    ->withMemoryOf('1GB')
+    ->withSizeId(1)
     ->runningPhp('7.1')
     ->withMariaDb('my-database-name')
     ->save();

--- a/src/Laravel/Commands/ForgeServers.php
+++ b/src/Laravel/Commands/ForgeServers.php
@@ -135,8 +135,8 @@ class ForgeServers extends Command
     protected function createServer(Provider $provider)
     {
         if ($provider->provider() !== 'custom') {
-            $size = $this->choice('Choose server size', array_keys($provider->sizes()));
-            $provider->withMemoryOf($size);
+            $size = $this->ask('Enter the server size ID');
+            $provider->withSizeId($size);
 
             $regions = $provider->regions();
 

--- a/src/Servers/Providers/Custom.php
+++ b/src/Servers/Providers/Custom.php
@@ -25,14 +25,6 @@ class Custom extends Provider
     /**
      * @{inheritdoc}
      */
-    public function memoryAvailable($memory)
-    {
-        return true;
-    }
-
-    /**
-     * @{inheritdoc}
-     */
     public function validate()
     {
         $errors = [];

--- a/src/Servers/Providers/Provider.php
+++ b/src/Servers/Providers/Provider.php
@@ -100,18 +100,6 @@ abstract class Provider
     }
 
     /**
-     * Determines if given memory size is available at current provider.
-     *
-     * @param string|int $memory
-     *
-     * @return bool
-     */
-    public function memoryAvailable($memory)
-    {
-        return $this->resourceAvailable($this->sizes(), $memory);
-    }
-
-    /**
      * Determines if given resource exists in resources list.
      *
      * @param array $resources
@@ -165,19 +153,19 @@ abstract class Provider
     }
 
     /**
-     * Set memory / server size.
+     * Set server size ID.
      *
-     * @param int|string $memory
+     * @param int|string $sizeId
      *
      * @return static
      */
-    public function withMemoryOf($memory)
+    public function withSizeId($sizeId)
     {
-        if (!$this->memoryAvailable($memory)) {
-            throw new InvalidArgumentException('Given memory value is not supported by '.$this->provider().' provider.');
+        if (!is_numeric(ltrim($sizeId, 0))) {
+            throw new InvalidArgumentException('Given server size ID is not valid');
         }
 
-        $this->payload['size'] = $memory;
+        $this->payload['size'] = (int) $sizeId;
 
         return $this;
     }

--- a/tests/CreateServerTest.php
+++ b/tests/CreateServerTest.php
@@ -105,7 +105,7 @@ class CreateServerTest extends TestCase
             'php_version' => 'php71',
             'provider' => 'ocean2',
             'region' => 'fra1',
-            'size' => '512MB',
+            'size' => 1,
         ], $replace);
     }
 
@@ -126,7 +126,57 @@ class CreateServerTest extends TestCase
                     return $forge
                         ->create()
                         ->droplet('northrend')
-                        ->withMemoryOf('512MB')
+                        ->withSizeId(1)
+                        ->usingCredential(1)
+                        ->at('fra1')
+                        ->runningPhp('7.1')
+                        ->withMariaDb('laravel')
+                        ->asNodeBalancer()
+                        ->connectedTo([1, 2, 3])
+                        ->save();
+                },
+            ],
+            [
+                'payload' => $this->payload(
+                    [
+                        'size' => 19
+                    ]
+                ),
+                'response' => $this->response(
+                    [
+                        'size' => 19
+                    ]
+                ),
+                'factory' => function (Forge $forge) {
+                    return $forge
+                        ->create()
+                        ->droplet('northrend')
+                        ->withSizeId(19)
+                        ->usingCredential(1)
+                        ->at('fra1')
+                        ->runningPhp('7.1')
+                        ->withMariaDb('laravel')
+                        ->asNodeBalancer()
+                        ->connectedTo([1, 2, 3])
+                        ->save();
+                },
+            ],
+            [
+                'payload' => $this->payload(
+                    [
+                        'size' => 2
+                    ]
+                ),
+                'response' => $this->response(
+                    [
+                        'size' => 2
+                    ]
+                ),
+                'factory' => function (Forge $forge) {
+                    return $forge
+                        ->create()
+                        ->droplet('northrend')
+                        ->withSizeId("02")
                         ->usingCredential(1)
                         ->at('fra1')
                         ->runningPhp('7.1')
@@ -145,7 +195,7 @@ class CreateServerTest extends TestCase
                     return $forge
                         ->create()
                         ->droplet('northrend')
-                        ->withMemoryOf('512MB')
+                        ->withSizeId(1)
                         ->usingCredential(1)
                         ->at('fra1')
                         ->runningPhp('7.1')
@@ -166,7 +216,7 @@ class CreateServerTest extends TestCase
                     return $forge
                         ->create()
                         ->droplet('northrend')
-                        ->withMemoryOf('512MB')
+                        ->withSizeId(1)
                         ->usingCredential(1)
                         ->at('fra1')
                         ->runningPhp('7.2')
@@ -179,18 +229,18 @@ class CreateServerTest extends TestCase
             [
                 'payload' => $this->payload([
                     'provider' => 'linode',
-                    'size' => '1GB',
+                    'size' => 2,
                     'region' => 10,
                 ]),
                 'response' => $this->response([
-                    'size' => '1GB',
+                    'size' => 2,
                     'region' => 'Frankfurt',
                 ]),
                 'factory' => function (Forge $forge) {
                     return $forge
                         ->create()
                         ->linode('northrend')
-                        ->withMemoryOf('1GB')
+                        ->withSizeId(2)
                         ->usingCredential(1)
                         ->at(10)
                         ->runningPhp('7.1')
@@ -203,18 +253,18 @@ class CreateServerTest extends TestCase
             [
                 'payload' => $this->payload([
                     'provider' => 'aws',
-                    'size' => '1GB',
+                    'size' => 2,
                     'region' => 'us-west-1',
                 ]),
                 'response' => $this->response([
-                    'size' => '1GB',
+                    'size' => 2,
                     'region' => 'us-west-1'
                 ]),
                 'factory' => function (Forge $forge) {
                     return $forge
                         ->create()
                         ->aws('northrend')
-                        ->withMemoryOf('1GB')
+                        ->withSizeId(2)
                         ->usingCredential(1)
                         ->at('us-west-1')
                         ->runningPhp('7.1')
@@ -227,20 +277,20 @@ class CreateServerTest extends TestCase
             [
                 'payload' => $this->payload([
                     'provider' => 'aws',
-                    'size' => '1GB',
+                    'size' => 3,
                     'region' => 'us-west-1',
                     'database_type' => 'postgres',
                     'maria' => 0,
                 ]),
                 'response' => $this->response([
-                    'size' => '1GB',
+                    'size' => 3,
                     'region' => 'us-west-1'
                 ]),
                 'factory' => function (Forge $forge) {
                     return $forge
                         ->create()
                         ->aws('northrend')
-                        ->withMemoryOf('1GB')
+                        ->withSizeId(3)
                         ->usingCredential(1)
                         ->at('us-west-1')
                         ->runningPhp('7.1')
@@ -260,13 +310,13 @@ class CreateServerTest extends TestCase
                     'php_version' => 'php71',
                     'private_ip_address' => '10.129.3.252',
                     'provider' => 'custom',
-                    'size' => '5GB',
+                    'size' => 13,
                 ],
                 'response' => [
                     'id' => 1,
                     'credential_id' => 0,
                     'name' => 'northrend',
-                    'size' => '5GB',
+                    'size' => 13,
                     'php_version' => 'php71',
                     'ip_address' => '37.139.3.148',
                     'private_ip_address' => '10.129.3.252',
@@ -282,7 +332,7 @@ class CreateServerTest extends TestCase
                     return $forge
                         ->create()
                         ->custom('northrend')
-                        ->withMemoryOf('5GB')
+                        ->withSizeId(13)
                         ->runningPhp('7.1')
                         ->withMariaDb('laravel')
                         ->usingPublicIp('37.139.3.148')
@@ -304,7 +354,7 @@ class CreateServerTest extends TestCase
                     return $forge
                         ->create()
                         ->droplet('northrend')
-                        ->withMemoryOf('512MB')
+                        ->withSizeId(1)
                         ->at('fra1')
                         ->runningPhp('7.1')
                         ->withMariaDb('laravel')
@@ -318,15 +368,15 @@ class CreateServerTest extends TestCase
                 'payload' => $this->payload([
                     'provider' => 'linode',
                     'credential_id' => 3,
-                    'size' => '1GB',
+                    'size' => 1,
                     'region' => 10,
                 ]),
-                'response' => $this->response(['size' => '1GB']),
+                'response' => $this->response(['size' => 1]),
                 'factory' => function (Forge $forge) {
                     return $forge
                         ->create()
                         ->linode('northrend')
-                        ->withMemoryOf('1GB')
+                        ->withSizeId(1)
                         ->at(10)
                         ->runningPhp('7.1')
                         ->withMariaDb('laravel')

--- a/tests/Helpers/Api.php
+++ b/tests/Helpers/Api.php
@@ -46,7 +46,7 @@ class Api
             'id' => 1,
             'credential_id' => 1,
             'name' => 'northrend',
-            'size' => '512MB',
+            'size' => 1,
             'region' => 'Amsterdam 2',
             'php_version' => 'php71',
             'ip_address' => '37.139.3.148',
@@ -92,8 +92,8 @@ class Api
     /**
      * Create fake site.
      *
-     * @param \Closure $callback = null
-     * @param array $replaceSiteData = []
+     * @param \Closure $callback        = null
+     * @param array    $replaceSiteData = []
      *
      * @return \Laravel\Forge\Sites\Site
      */
@@ -108,8 +108,8 @@ class Api
     /**
      * Create fake server.
      *
-     * @param \Closure $callback = null
-     * @param array $replaceServerData = []
+     * @param \Closure $callback          = null
+     * @param array    $replaceServerData = []
      *
      * @return \Laravel\Forge\Server
      */
@@ -131,7 +131,7 @@ class Api
     /**
      * Create multiple fake servers.
      *
-     * @param int $number
+     * @param int      $number
      * @param \Closure $callback
      *
      * @return \Laravel\Forge\Server


### PR DESCRIPTION
It seems that when defining the size of a server, we now need to use an ID, rather than a memory size.
Code, docs and tests have been changed and documentation of the current provider regions and server sizes has been added.

This is a breaking change to the code, but it is also a breaking change to the API really, so I don't see a way of avoiding it with the current implementation. very open to other solutions. Please let mw know what you think.