### PR TITLE
Add opcache support

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -49,7 +49,7 @@ $server->update([
 ```
 
 > Note on size/IP changes
-> 
+>
 > IP and RAM changes do not affect your server,
 > they only update Forge's knowledge about your server.
 
@@ -61,6 +61,26 @@ Use `reboot` method to reboot your server.
 <?php
 
 $server->reboot();
+```
+
+## Enable PHP OPCache server
+
+Use `enableOPCache` method to enable PHP OPCache on your server.
+
+```php
+<?php
+
+$server->enableOPCache();
+```
+
+## Disable PHP OPCache server
+
+Use `disableOPCache` method to disable PHP OPCache on your server.
+
+```php
+<?php
+
+$server->disableOPCache();
 ```
 
 ## Revoke Forge access to server

--- a/src/Server.php
+++ b/src/Server.php
@@ -182,6 +182,30 @@ class Server extends ApiResource
     }
 
     /**
+     * Enable PHP OPCache on the server.
+     *
+     * @return bool
+     */
+    public function enableOPCache(): bool
+    {
+        $this->getHttpClient()->request('POST', $this->apiUrl('/php/opcache'));
+
+        return true;
+    }
+
+    /**
+     * Disable PHP OPCache on the server.
+     *
+     * @return bool
+     */
+    public function disableOPCache(): bool
+    {
+        $this->getHttpClient()->request('DELETE', $this->apiUrl('/php/opcache'));
+
+        return true;
+    }
+
+    /**
      * Revoke Forge access to server.
      *
      * @return bool

--- a/tests/ServersTest.php
+++ b/tests/ServersTest.php
@@ -329,6 +329,26 @@ class ServersTests extends TestCase
                 'expectedResult' => true,
             ],
             [
+                'method' => 'enableOPCache',
+                'data' => Api::serverData(),
+                'operation' => [
+                    'method' => 'POST',
+                    'url' => 'servers/1/php/opcache',
+                ],
+                'response' => [],
+                'expectedResult' => true,
+            ],
+            [
+                'method' => 'disableOPCache',
+                'data' => Api::serverData(),
+                'operation' => [
+                    'method' => 'DELETE',
+                    'url' => 'servers/1/php/opcache',
+                ],
+                'response' => [],
+                'expectedResult' => true,
+            ],
+            [
                 'method' => 'revokeAccess',
                 'data' => Api::serverData(),
                 'operation' => [


### PR DESCRIPTION
Adds 2 methods to the server class to enable or disable PHP OPCache on the server. Docs and tests updated