### PR TITLE
Update guzzlehttp/guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2",


### PR DESCRIPTION
Support guzzlehttp/guzzle ^6.3 and ^7.0

Laravel 8 made guzzlehttp/guzzle to be ^7.0.1

https://github.com/laravel/laravel/blob/8.x/composer.json