### PR TITLE
fix: add return type after php 8.1 version or newest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
 
     name: PHP${{ matrix.php }}
 

--- a/src/Traits/ArrayAccessTrait.php
+++ b/src/Traits/ArrayAccessTrait.php
@@ -11,7 +11,7 @@ trait ArrayAccessTrait
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
@@ -22,7 +22,7 @@ trait ArrayAccessTrait
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->data[] = $value;
@@ -41,6 +41,7 @@ trait ArrayAccessTrait
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;
@@ -51,7 +52,7 @@ trait ArrayAccessTrait
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
 

--- a/src/Traits/LazyArrayAccess.php
+++ b/src/Traits/LazyArrayAccess.php
@@ -11,7 +11,7 @@ trait LazyArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->checkLazyLoad();
 
@@ -24,7 +24,7 @@ trait LazyArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->checkLazyLoad();
 
@@ -45,6 +45,7 @@ trait LazyArrayAccess
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->checkLazyLoad();
@@ -57,7 +58,7 @@ trait LazyArrayAccess
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->checkLazyLoad();
 

--- a/src/Traits/LazyIterator.php
+++ b/src/Traits/LazyIterator.php
@@ -9,6 +9,7 @@ trait LazyIterator
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->checkLazyLoad();
@@ -23,6 +24,7 @@ trait LazyIterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $this->checkLazyLoad();
@@ -33,7 +35,7 @@ trait LazyIterator
     /**
      * Increments iterator position.
      */
-    public function next()
+    public function next(): void
     {
         $this->checkLazyLoad();
 
@@ -43,7 +45,7 @@ trait LazyIterator
     /**
      * Rewinds iterator back to first position.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->checkLazyLoad();
 
@@ -55,7 +57,7 @@ trait LazyIterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->checkLazyLoad();
 


### PR DESCRIPTION
When using php8.1 or the newest version, got some deprecated messages.

<img width="2537" alt="截圖 2024-12-30 下午1 40 33" src="https://github.com/user-attachments/assets/fee8c1c5-496f-4c3c-9405-42df04f5b963" />

After:
<img width="765" alt="截圖 2024-12-30 下午1 41 53" src="https://github.com/user-attachments/assets/bbd2987d-cdd9-4229-b38d-2ff1275e3521" />

Also checking 7.4 version, all working
<img width="803" alt="截圖 2024-12-30 下午1 43 11" src="https://github.com/user-attachments/assets/00a813e2-0482-4a72-bf1f-0bc3e2aa89f4" />
